### PR TITLE
Fixing Coffee Script and Adding namespace

### DIFF
--- a/scripts/interfaces.coffee
+++ b/scripts/interfaces.coffee
@@ -18,8 +18,8 @@ module.exports = (server) ->
       continue if line.match /lo:/ 
       regex = /(.+):(.*)/
       matched = line.match(regex)
-      interface = matched[1].trim()
+      iface = matched[1].trim()
       values = matched[2].trim().split /\s+/
       statObj = {}
       statObj[key] = values[i] for key, i in nameArray
-      server.push_metric "#{metricPrefix}.#{interface}.#{key}", value for key, value of statObj 
+      server.push_metric "#{metricPrefix}.#{iface}.#{key}", value for key, value of statObj 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -9,6 +9,7 @@ class HoardD extends EventEmitter
   constructor: (@conf, @cli) ->
     @sPath = @conf.scriptPath
     @fqdn = @conf.fqdn.split('.').join('_')
+    @namespace = @conf.namespace or 'hoard'
     @samplesRun = 0
     @util = Util
 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -36,7 +36,7 @@ class HoardD extends EventEmitter
 
   push_metric: (prefix, value) ->
     try
-      metric = "hoard.#{prefix} #{value} #{@now()}"
+      metric = "#{@namespace}.#{prefix} #{value} #{@now()}"
       @pending.push metric
       @cli.debug metric
     catch error


### PR DESCRIPTION
Added a config option to allow the override of the root 'hoard' namespace. Also fixed a coffeescript error with 'interface' being a reserved word.
