### PR TITLE
Added support for metric collection for multiple mysql instances

### DIFF
--- a/scripts-available/mysql.coffee
+++ b/scripts-available/mysql.coffee
@@ -114,12 +114,10 @@ module.exports = (server) ->
 
     grep.stdout.on 'data', (data) ->
       greppedLines = ("" + data).split( "\n" )
-      console.log greppedLines
       i = 0
       while i < greppedLines.length
         unless greppedLines[i] is ""
           port = Math.round(/:([0-9][0-9][0-9][0-9])/.exec(data)[1])
-          console.log port
           conn = Mysql.createClient({
           "host":      conf.localhost,
           "user":      conf.user,

--- a/scripts-available/mysql.coffee
+++ b/scripts-available/mysql.coffee
@@ -94,30 +94,57 @@ module.exports = (server) ->
   run = () ->
     server.cli.debug "Running the mysql plugin"
     metricPrefix = "#{server.fqdn}.mysql"
+    port = 3306
     data         = {}
     # This script needs configuration
-    confPath     = Path.join server.sPath, 'mysql.json'
-    configFile   = Fs.readFileSync confPath, 'utf-8'
-    conf         = JSON.parse configFile
-    
-    conn = Mysql.createClient conf
-    conn.query 'SHOW GLOBAL STATUS', (err, res, fields) ->
-      if err
-        server.cli.error "Error on STATUS query: #{err}"
+    #confPath     = Path.join server.sPath, 'mysql.json'
+    #configFile   = Fs.readFileSync confPath, 'utf-8'
+    #conf         = JSON.parse configFile
 
-      for row in res
-        data[row.Variable_name] = row.Value
+    # Changes start from here :
+    {spawn} = require 'child_process'
+    netstat = spawn 'netstat', ['-ntpl']
+    grep = spawn 'grep', ['mysqld']
 
-      conn.query 'SHOW SLAVE STATUS', (err, res, fields) ->
-        if err
-          server.cli.error "Error on SLAVE STATUS query: #{err}"
+    netstat.stdout.on 'data', (data) ->
+      grep.stdin.write(data)
 
-        data[key] = value for key, value of res[0]
+    netstat.on 'close', (code) ->
+      server.cli.error "netstat process exited with code " + code  if code isnt 0
+      grep.stdin.end()
 
-        # Replication lag being null is bad, very bad, so negativate it here
-        data['Seconds_Behind_Master'] = -1 if data['Seconds_Behind_Master'] == null  
-        conn.end()
+    grep.stdout.on 'data', (data) ->
+      greppedLines = ("" + data).split( "\n" )
+      console.log greppedLines
+      i = 0
+      while i < greppedLines.length
+        unless greppedLines[i] is ""
+          port = Math.round(/:([0-9][0-9][0-9][0-9])/.exec(data)[1])
+          console.log port
+          conn = Mysql.createClient({
+          "host":      "localhost",
+          "user":      "hoardd_user",
+          "password":  "hoardd_pass",
+          "port": port
+          })
+          conn.query 'SHOW GLOBAL STATUS', (err, res, fields) ->
+            if err
+              server.cli.error "Error on STATUS query: #{err}"
 
-        for name, group of metricGroups
-          server.push_metric("#{metricPrefix}.#{name}.#{key}", 
-                              data[stat]) for key, stat of group 
+            for row in res
+              data[row.Variable_name] = row.Value
+
+            conn.query 'SHOW SLAVE STATUS', (err, res, fields) ->
+              if err
+                server.cli.error "Error on SLAVE STATUS query: #{err}"
+
+              data[key] = value for key, value of res[0]
+
+              # Replication lag being null is bad, very bad, so negativate it here
+              data['Seconds_Behind_Master'] = -1 if data['Seconds_Behind_Master'] == null  
+              conn.end()
+
+              for name, group of metricGroups
+                server.push_metric("#{metricPrefix}.#{port}.#{name}.#{key}", 
+                                    data[stat]) for key, stat of group 
+        i++

--- a/scripts-available/mysql.coffee
+++ b/scripts-available/mysql.coffee
@@ -96,12 +96,7 @@ module.exports = (server) ->
     metricPrefix = "#{server.fqdn}.mysql"
     port = 3306
     data         = {}
-    # This script needs configuration
-    #confPath     = Path.join server.sPath, 'mysql.json'
-    #configFile   = Fs.readFileSync confPath, 'utf-8'
-    #conf         = JSON.parse configFile
-
-    # Changes start from here :
+    
     {spawn} = require 'child_process'
     netstat = spawn 'netstat', ['-ntpl']
     grep = spawn 'grep', ['mysqld']

--- a/scripts-available/mysql.coffee
+++ b/scripts-available/mysql.coffee
@@ -117,7 +117,7 @@ module.exports = (server) ->
       i = 0
       while i < greppedLines.length
         unless greppedLines[i] is ""
-          port = Math.round(/:([0-9][0-9][0-9][0-9])/.exec(data)[1])
+          port = Math.round(/:([0-9][0-9][0-9][0-9])/.exec(greppedLines[i])[1])
           conn = Mysql.createClient({
           "host":      conf.localhost,
           "user":      conf.user,

--- a/scripts-available/mysql.coffee
+++ b/scripts-available/mysql.coffee
@@ -96,6 +96,10 @@ module.exports = (server) ->
     metricPrefix = "#{server.fqdn}.mysql"
     port = 3306
     data         = {}
+    # This script needs configuration
+    confPath     = Path.join server.sPath, 'mysql.json'
+    configFile   = Fs.readFileSync confPath, 'utf-8'
+    conf         = JSON.parse configFile
     
     {spawn} = require 'child_process'
     netstat = spawn 'netstat', ['-ntpl']
@@ -117,9 +121,9 @@ module.exports = (server) ->
           port = Math.round(/:([0-9][0-9][0-9][0-9])/.exec(data)[1])
           console.log port
           conn = Mysql.createClient({
-          "host":      "localhost",
-          "user":      "hoardd_user",
-          "password":  "hoardd_pass",
+          "host":      conf.localhost,
+          "user":      conf.user,
+          "password":  conf.password,
           "port": port
           })
           conn.query 'SHOW GLOBAL STATUS', (err, res, fields) ->

--- a/scripts-available/mysql.json
+++ b/scripts-available/mysql.json
@@ -1,5 +1,6 @@
 {
 "host":      "localhost",
 "user":      "debian-sys-maint", 
-"password":  "IAut3aCOzvne3y5w" 
+"password":  "IAut3aCOzvne3y5w",
+"multiserver": 0
 }


### PR DESCRIPTION
First, thanks for this awesome tool. It's been incredibly useful.

We had two issues with the mysql coffee script:
1) We needed to collect metrics from all mysql instances running on a box
2) If mysql is not running, hoardd shouldn't exit with an error

Both of these have been addressed in this commit.

Sample output:

DEBUG: hoard.localhost.mysql.<b>3306</b>.general.txBytes 130245 1389338486
DEBUG: hoard.localhost.mysql.<b>3306</b>.general.keyRead_requests 0 1389338486
DEBUG: hoard.localhost.mysql.<b>3306</b>.general.keyReads 0 1389338486
DEBUG: hoard.localhost.mysql.<b>3306</b>.general.keyWrite_requests 0 1389338486
DEBUG: hoard.localhost.mysql.<b>3306</b>.general.keyWrites 0 1389338486

As you can see, metrics between instances will be differentiated between using port number.

EDIT: This has been tested successfully on Ubuntu 12.04.
