### PR TITLE
Replacing path.existsSync with fs.existsSync

### DIFF
--- a/scripts/interfaces.coffee
+++ b/scripts/interfaces.coffee
@@ -16,6 +16,7 @@ module.exports = (server) ->
     content = Fs.readFileSync(procfile, 'ascii').trim()
     for line in content.split('\n')[2...]
       continue if line.match /lo:/ 
+      continue if line.match /veth[a-zA-Z0-9]+:/ 
       regex = /(.+):(.*)/
       matched = line.match(regex)
       iface = matched[1].trim()

--- a/scripts/load_avg.coffee
+++ b/scripts/load_avg.coffee
@@ -1,5 +1,5 @@
 Fs = require 'fs'
-Path = require 'path'
+Fs = require 'fs'
 
 module.exports = (server) ->
   run = () ->
@@ -8,7 +8,7 @@ module.exports = (server) ->
 
     # Read from /proc
     procfile = '/proc/loadavg'
-    if Path.existsSync procfile
+    if Fs.existsSync procfile
       data = Fs.readFileSync(procfile, 'utf-8')
       [one, five, fifteen] = data.split(' ', 3)
       server.push_metric "#{metricPrefix}.short", one

--- a/src/start.coffee
+++ b/src/start.coffee
@@ -1,5 +1,4 @@
 Server = require './server'
-Path   = require 'path'
 Cli    = require('cli').enable('status', 'version')
 Fs     = require 'fs'
 
@@ -12,7 +11,7 @@ module.exports = entry_point = () ->
     'config': ['c', 'Configuration file path', 'path', './config.json']
 
   Cli.main (args, options) ->
-    if Path.existsSync options.config
+    if Fs.existsSync options.config
       try
         conf = JSON.parse(Fs.readFileSync(options.config, 'utf-8'))
       catch error


### PR DESCRIPTION
It appears that the former has been deprecated a while ago. Actually the latter will be deprecated at a later point as well, so this won't keep working forever. But at least it works today.
